### PR TITLE
I am trying to build FAMIX model out of production PostgreSQL database, here my fixes.

### DIFF
--- a/src/PostgreSQL-AST-Builder-Tests/PSQLSharedASTBuilderTest.class.st
+++ b/src/PostgreSQL-AST-Builder-Tests/PSQLSharedASTBuilderTest.class.st
@@ -135,17 +135,20 @@ PSQLSharedASTBuilderTest >> testUpdateDeleteWhereClause [
 { #category : #'tests-shared' }
 PSQLSharedASTBuilderTest >> testWithClause [
 	| node |
-	node := builder withClause parse: 'WITH table AS (SELECT * FROM foo), table2(id,text) AS (SELECT * FROM bar)'.
+	node := builder withClause
+		parse:
+			'WITH table AS (SELECT * FROM foo), table2(id,text) AS (SELECT * FROM bar)'.
 	self
 		assert: node class equals: PSQLASTWithClause;
 		deny: node isRecursive;
 		assert: node queries size equals: 2.
-		
-	node := builder withClause parse: 'WITH RECURSIVE table AS (SELECT * FROM foo), table2(id,text) AS (SELECT * FROM bar)'.
+	node := builder withClause
+		parse:
+			'WITH RECURSIVE table AS (SELECT * FROM foo), table2(id,text) AS (SELECT id as i FROM bar)'.
 	self
 		assert: node class equals: PSQLASTWithClause;
 		assert: node isRecursive;
-		assert: node queries size equals: 2.
+		assert: node queries size equals: 2
 ]
 
 { #category : #'tests-shared' }
@@ -153,16 +156,18 @@ PSQLSharedASTBuilderTest >> testWithQuery [
 	| node |
 	node := builder withQuery parse: 'table AS (SELECT * FROM foo)'.
 	self
-		assert: node class equals: Association;
-		assert: node key class equals: PSQLASTTableAlias;
-		assert: node key identifier identifier equals: 'table';
-		assert: node key columnAliases size equals: 0.
-		
-	node := builder withQuery parse: 'table(id,bar) AS (SELECT * FROM foo)'.
+		assert: node class equals: PSQLASTSelectQuery;
+		assert: node alias class equals: PSQLASTTableAlias;
+		assert: node alias identifier identifier equals: 'table';
+		assert: node alias columnAliases size equals: 0.
+	node := builder withQuery
+		parse: 'table(id,bar) AS (SELECT * FROM foo)'.
 	self
-		assert: node class equals: Association;
-		assert: node key class equals: PSQLASTTableAlias;
-		assert: node key identifier identifier equals: 'table';
-		assert: node key columnAliases size equals: 2;
-		assert: (node key columnAliases allSatisfy: [ :item | item class = PSQLASTIdentifier ])
+		assert: node class equals: PSQLASTSelectQuery;
+		assert: node alias class equals: PSQLASTTableAlias;
+		assert: node alias identifier identifier equals: 'table';
+		assert: node alias columnAliases size equals: 2;
+		assert:
+			(node alias columnAliases
+				allSatisfy: [ :item | item class = PSQLASTIdentifier ])
 ]

--- a/src/PostgreSQL-AST-Builder/PSQLSharedASTBuilder.class.st
+++ b/src/PostgreSQL-AST-Builder/PSQLSharedASTBuilder.class.st
@@ -105,9 +105,18 @@ PSQLSharedASTBuilder >> withClause [
 
 { #category : #shared }
 PSQLSharedASTBuilder >> withQuery [
-	^ super withQuery psqlASTBuild: [ :tokens |
-		(PSQLASTTableAlias new
-			identifier: tokens first;
-			columnAliases: (tokens second ifNotNil: [ :array | array second reject: [ :token | token = $, ] ]  ifNil: [ #() ]);
-			yourself) -> tokens fifth ]
+
+	^ super withQuery
+		psqlASTBuild: [ :tokens | 
+			"tokens fifth should be PSQLASTSelectQuery"
+			tokens fifth
+				alias:
+					(PSQLASTTableAlias new
+						identifier: tokens first;
+						columnAliases:
+							(tokens second
+								ifNotNil: [ :array | array second reject: [ :token | token = $, ] ]
+								ifNil: [ #() ]);
+						yourself);
+				yourself ]
 ]

--- a/src/PostgreSQL-AST/PSQLASTCRUDQuery.class.st
+++ b/src/PostgreSQL-AST/PSQLASTCRUDQuery.class.st
@@ -5,10 +5,26 @@ Class {
 	#name : #PSQLASTCRUDQuery,
 	#superclass : #PSQLASTNode,
 	#instVars : [
-		'withClause'
+		'withClause',
+		'alias'
 	],
 	#category : #'PostgreSQL-AST-SQL-CRUD'
 }
+
+{ #category : #accessing }
+PSQLASTCRUDQuery >> alias [
+	^ alias
+]
+
+{ #category : #accessing }
+PSQLASTCRUDQuery >> alias: anObject [
+	alias := anObject
+]
+
+{ #category : #testing }
+PSQLASTCRUDQuery >> hasAlias [
+	^ self alias isNotNil
+]
 
 { #category : #testing }
 PSQLASTCRUDQuery >> hasWithClause [

--- a/src/PostgreSQL-AST/PSQLASTDeleteQuery.class.st
+++ b/src/PostgreSQL-AST/PSQLASTDeleteQuery.class.st
@@ -10,8 +10,7 @@ Class {
 		'returningClause',
 		'isOnlySpecified',
 		'areDescendantTablesIncluded',
-		'tableName',
-		'alias'
+		'tableName'
 	],
 	#category : #'PostgreSQL-AST-SQL-CRUD'
 }
@@ -22,16 +21,6 @@ PSQLASTDeleteQuery >> acceptVisitor: aVisitor [
 ]
 
 { #category : #accessing }
-PSQLASTDeleteQuery >> alias [
-	^ alias
-]
-
-{ #category : #accessing }
-PSQLASTDeleteQuery >> alias: anObject [
-	alias := anObject
-]
-
-{ #category : #accessing }
 PSQLASTDeleteQuery >> areDescendantTablesIncluded [
 	^ areDescendantTablesIncluded
 ]
@@ -39,11 +28,6 @@ PSQLASTDeleteQuery >> areDescendantTablesIncluded [
 { #category : #accessing }
 PSQLASTDeleteQuery >> areDescendantTablesIncluded: anObject [
 	areDescendantTablesIncluded := anObject
-]
-
-{ #category : #testing }
-PSQLASTDeleteQuery >> hasAlias [
-	^ self alias isNotNil
 ]
 
 { #category : #testing }

--- a/src/PostgreSQL-AST/PSQLASTInsertQuery.class.st
+++ b/src/PostgreSQL-AST/PSQLASTInsertQuery.class.st
@@ -9,7 +9,6 @@ Class {
 		'onConflictClause',
 		'valuesClause',
 		'tableName',
-		'alias',
 		'columns'
 	],
 	#category : #'PostgreSQL-AST-SQL-CRUD'
@@ -21,16 +20,6 @@ PSQLASTInsertQuery >> acceptVisitor: aVisitor [
 ]
 
 { #category : #accessing }
-PSQLASTInsertQuery >> alias [
-	^ alias
-]
-
-{ #category : #accessing }
-PSQLASTInsertQuery >> alias: anObject [
-	alias := anObject
-]
-
-{ #category : #accessing }
 PSQLASTInsertQuery >> columns [
 	^ columns
 ]
@@ -38,11 +27,6 @@ PSQLASTInsertQuery >> columns [
 { #category : #accessing }
 PSQLASTInsertQuery >> columns: anObject [
 	columns := anObject
-]
-
-{ #category : #testing }
-PSQLASTInsertQuery >> hasAlias [
-	^ self alias isNotNil
 ]
 
 { #category : #testing }

--- a/src/PostgreSQL-AST/PSQLASTNode.class.st
+++ b/src/PostgreSQL-AST/PSQLASTNode.class.st
@@ -72,17 +72,22 @@ PSQLASTNode >> breadthFirstIterator [
 { #category : #'accessing - reflective' }
 PSQLASTNode >> children [
 	| children |
-	children := OrderedCollection streamContents: [ :stream | 
-			self instanceVariableNamesToChildrenDo: [ :instVarName :nodeOrCollection |
-				stream nextPutAll: nodeOrCollection asOrderedCollection ] ].
-	(children allSatisfy: [ :node | node startPosition isNotNil and: [ node endPosition isNotNil ] ])
-		ifFalse: [ 
-			Warning signal: 'All positions of children are not set. Returning unordered children.'.
+	children := OrderedCollection
+		streamContents: [ :stream | 
+			self
+				instanceVariableNamesToChildrenDo:
+					[ :instVarName :nodeOrCollection | stream nextPutAll: nodeOrCollection asOrderedCollection ] ].
+	children := children reject: [ :node | node = self ].
+	(children
+		allSatisfy:
+			[ :node | node startPosition isNotNil and: [ node endPosition isNotNil ] ])
+		ifFalse: [ Warning
+				signal: 'All positions of children are not set. Returning unordered children.'.
 			^ children ].
-
-	^ children sort: [ :nodeA :nodeB |
-		nodeA startPosition < nodeB startPosition
-			and: [ nodeA endPosition < nodeB endPosition ] ]
+	^ children
+		sort: [ :nodeA :nodeB | 
+			nodeA startPosition < nodeB startPosition
+				and: [ nodeA endPosition < nodeB endPosition ] ]
 ]
 
 { #category : #enumerating }
@@ -797,9 +802,11 @@ PSQLASTNode >> root [
 
 { #category : #'parent management' }
 PSQLASTNode >> setChildrenParent [
-	self childrenDo: [ :child |
-		child parent: self.
-		child setChildrenParent ]
+	self
+		childrenDo: [ :child | 
+			child = self
+				ifFalse: [ child parent: self. child setChildrenParent ]
+			 ]
 ]
 
 { #category : #accessing }
@@ -809,7 +816,7 @@ PSQLASTNode >> sourceCode [
 	
 	"If I hold no source code but I have a parent, I ask my parent because the top parent will hold the source code."
 	self hasParent
-		ifTrue: [ ^ self parent sourceCode ].
+		ifTrue: [ self = self parent ifTrue: [^ nil] ifFalse: [^ self parent sourceCode ]].
 	
 	"If I have no parent, I am at the top of the AST. Since I have no source code, I return nil."
 	^ nil

--- a/src/PostgreSQL-AST/PSQLASTUpdateQuery.class.st
+++ b/src/PostgreSQL-AST/PSQLASTUpdateQuery.class.st
@@ -6,7 +6,6 @@ Class {
 	#superclass : #PSQLASTCRUDQuery,
 	#instVars : [
 		'tableName',
-		'alias',
 		'setClause',
 		'fromClause',
 		'whereClause',
@@ -20,16 +19,6 @@ Class {
 { #category : #visiting }
 PSQLASTUpdateQuery >> acceptVisitor: aVisitor [
 	^ aVisitor visitPSQLASTUpdateQuery: self
-]
-
-{ #category : #accessing }
-PSQLASTUpdateQuery >> alias [
-	^ alias
-]
-
-{ #category : #accessing }
-PSQLASTUpdateQuery >> alias: anObject [
-	alias := anObject
 ]
 
 { #category : #accessing }
@@ -50,11 +39,6 @@ PSQLASTUpdateQuery >> fromClause [
 { #category : #accessing }
 PSQLASTUpdateQuery >> fromClause: anObject [
 	fromClause := anObject
-]
-
-{ #category : #testing }
-PSQLASTUpdateQuery >> hasAlias [
-	^ self alias isNotNil
 ]
 
 { #category : #testing }

--- a/src/PostgreSQL-AST/PSQLPlpgSQLASTSearchedCase.class.st
+++ b/src/PostgreSQL-AST/PSQLPlpgSQLASTSearchedCase.class.st
@@ -17,7 +17,9 @@ PSQLPlpgSQLASTSearchedCase >> acceptVisitor: aVisitor [
 
 { #category : #accessing }
 PSQLPlpgSQLASTSearchedCase >> conditionToStatements [
-	self shouldNotImplement
+	"self shouldNotImplement"
+	self flag: #TODO.
+	super conditionToStatements 
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
1. Using alias instVar to store query alias in the WithClause and WithQuery Instead of Association. Association breaks parsing process and prevents FAMIX model creation. Actually alias can be used in WITH, SELECT, UPDATE, DELETE and INSERT queries, so I moved it into parent class PSQLASTCRUDQuery. Tests were adjusted to the new approach.

2. There are several cases when I've got infinite recursion due to parent being the same as self. So I've put several checks to avoid infinite recursion.

3. PSQLPlpgSQLASTSearchedCase>>conditionToStatements was really called in my setup, so I just enabled it, but have no idea how to implement it.